### PR TITLE
Adding Postman Collection generation template and instructions.

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,25 @@
+## postman.tmpl
+
+This method of Postman Collection generation relies on the documentation generator for `protoc`: https://github.com/pseudomuto/protoc-gen-doc
+
+Install with:
+```
+go get -u github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
+```
+
+Download the `postman.tmpl` file locally.
+
+Building the collection for `helloworld.proto`:
+
+```bash
+POSTMAN_COLLECTION_NAME="Hello World gRPC JSON API" protoc \
+--doc_out=./ \
+--doc_opt=./postman.tmpl,helloworld_collection.json \
+helloworld.proto
+```
+
+Try importing one of these example collections into Postman.  View the documentation and requests to see all populated fields.
+
+Hello World Collection: https://gist.githubusercontent.com/kevinswiber/867699e4efe57ccde83fb510c9de6075/raw/b082f5505b22112d5f989dae2765a065de2e53fd/zz_helloworld_collection.json
+
+Route Guide Collection: https://gist.githubusercontent.com/kevinswiber/867699e4efe57ccde83fb510c9de6075/raw/b082f5505b22112d5f989dae2765a065de2e53fd/zz_route_guide.proto

--- a/tools/gen_collection_example.sh
+++ b/tools/gen_collection_example.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+POSTMAN_COLLECTION_NAME="Hello World gRPC JSON API" protoc \
+--doc_out=./ \
+--doc_opt=./postman.tmpl,helloworld_collection.json \
+helloworld.proto

--- a/tools/helloworld.proto
+++ b/tools/helloworld.proto
@@ -1,0 +1,37 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a "greeting"
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}

--- a/tools/helloworld_collection.json
+++ b/tools/helloworld_collection.json
@@ -1,0 +1,52 @@
+{
+  "info": {
+    "name": "Hello World gRPC JSON API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "## Messages\n\n#### helloworld.HelloReply\n\nThe response message containing the greetings\n\n| Field | Type | Description |\n| ----- | ---- | ----------- |\n| message | string |  |\n\n#### helloworld.HelloRequest\n\nThe request message containing the user's name.\n\n| Field | Type | Description |\n| ----- | ---- | ----------- |\n| name | string |  |\n\n"
+  },
+  "item": [
+    {
+      "name": "helloworld.proto",
+      "description": "",
+      "item": [
+        {
+          "name": "helloworld.Greeter",
+          "description": "The greeting service definition.",
+          "items": [
+            {
+              "name": "SayHello",
+              "request": {
+                "description": "Sends a \"greeting\"\n\n\n\nRequest Message: `helloworld.HelloRequest`\n\nResponse Message: `helloworld.HelloReply`\n",
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/grpc+json"
+                  },
+                  {
+                    "key": "Grpc-Insecure",
+                    "value": "{{grpcInsecure}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseURL}}/helloworld.Greeter/SayHello",
+                  "host": [
+                    "{{baseURL}}"
+                  ],
+                  "path": [
+                    "helloworld.Greeter",
+                    "SayHello"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"name\": \"\"\n}"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tools/postman.tmpl
+++ b/tools/postman.tmpl
@@ -1,0 +1,94 @@
+{{- $messages := (index .Files 0).Messages -}}
+{{- if gt (len .Files) 1 -}}
+{{- range $file := (slice .Files 1) -}}
+{{- $messages = concat $messages $file.Messages -}}
+{{- end -}}
+{{- end -}}
+{
+  "info": {
+    "name": "{{coalesce (env "POSTMAN_COLLECTION_NAME") "Imported gRPC JSON API"}}",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "## Messages\n\n
+{{- range $msg := $messages }}
+{{- $msgDesc := (toJson $msg.Description) }}#### {{ $msg.FullName }}\n\n
+{{- substr 1 (int (sub (len $msgDesc) 1)) $msgDesc }}\n\n
+{{- if $msg.HasFields }}| Field | Type | Description |\n| ----- | ---- | ----------- |\n
+{{- range $f := $msg.Fields }}
+{{- $desc := (toJson $f.Description) }}{{ $descLen := len $desc}}| {{$f.Name}} | {{$f.FullType}} | {{substr 1 (int (sub (len $desc) 1)) $desc}} |\n
+{{- end }}
+{{- end }}\n
+{{- end }}"
+  },
+  "item": [
+{{- $fileLen := len .Files }}
+{{- range $fileIndex, $file := .Files -}}
+{{- if $file.HasServices }}
+    {
+      "name": "{{$file.Name}}",
+      "description": {{$file.Description | toJson }},
+      "item": [
+{{- $serviceLen := len $file.Services}}
+{{- range $serviceIndex, $service := .Services}}
+        {
+          "name": "{{$service.FullName}}",
+          "description": {{$service.Description | toJson }},
+          "items": [
+{{- $methodLen := len $service.Methods}}
+{{- range $methodIndex, $method := $service.Methods}}
+            {
+              "name": "{{$method.Name}}",
+              "request": {
+                "description": {{(printf "%s\n\n\n\nRequest Message: `%s`\n\nResponse Message: `%s`\n" $method.Description $method.RequestFullType $method.ResponseFullType) | toJson }},
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/grpc+json"
+                  },
+                  {
+                    "key": "Grpc-Insecure",
+                    "value": "{{"{{"}}grpcInsecure{{"}}"}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{"{{"}}baseURL{{"}}"}}/{{$service.FullName}}/{{$method.Name}}",
+                  "host": [
+                    "{{"{{"}}baseURL{{"}}"}}"
+                  ],
+                  "path": [
+                    "{{$service.FullName}}",
+                    "{{$method.Name}}"
+                  ]
+                },
+                "body": {
+                  "mode": "raw",
+{{- range $msg := $messages -}}
+{{if eq $msg.FullName $method.RequestFullType }}
+                  "raw": "{\n
+{{- $fieldLen := len $msg.Fields -}}
+{{- range $fieldIndex, $field := $msg.Fields -}}
+{{"  \\\""}}{{$field.Name}}\": {{ if eq $field.FullType "string" -}}
+{{- "\\\"\\\"" -}}
+{{- else if eq $field.FullType "bool" -}}
+{{- "true" -}}
+{{- else if (has $field.FullType (list "int" "int32" "int64" "double" "float" "uint32" "uint64" "sint32" "sint64" "fixed32" "fixed64" "sfixed32" "sfixed64")) -}}
+{{- "0" -}}
+{{- else -}}
+{{- "{}" -}}
+{{- end -}}{{if lt $fieldIndex (sub $fieldLen 1)}},\n{{end}}
+{{- end }}\n}"
+                }
+{{- end }}
+{{- end }}
+              }
+            }{{if lt $methodIndex (sub $methodLen 1)}},{{end}}
+{{- end}}
+          ]
+        }{{if lt $serviceIndex (sub $serviceLen 1)}},{{end}}
+      ]
+{{- end}}
+    }{{if (lt $fileIndex (sub $fileLen 1))}}{{if (first (slice $.Files (add $fileIndex 1) 1)).HasServices}},{{end}}{{end}}
+{{- end}}
+{{- end}}
+  ]
+}


### PR DESCRIPTION
I put together a template for generating Postman collections from gRPC proto files.

Here's an example of the kind of documentation it generates: https://documenter.getpostman.com/view/10825459/Szf83Trt?version=latest

You can use the Run in Postman button on that page to actually load it into Postman.  The gRPC server for this particular example can be built from the generated `route_guide` example that comes with `grpc/grpc`.  It can be found at `$GOPATH/pkg/mod/google.golang.org/grpc@v1.28.1/examples/route_guide/` when installed locally.

I do have this all hosted as a gist.  Just wanted to offer it here if you think there's value having it as a part of this repo.  Here's the gist, for posterity: https://gist.github.com/kevinswiber/867699e4efe57ccde83fb510c9de6075.

How this looks in Postman:
<img width="1066" alt="image" src="https://user-images.githubusercontent.com/78582/79959467-07f94380-8439-11ea-9571-8fdcafdcf80a.png">


Signed-off-by: Kevin Swiber <kswiber@gmail.com>